### PR TITLE
Switch fabric-lib-go to use fabric-core-maintainers.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Fabric lib go Maintainers
-*       @hyperledger/fabric-lib-go-maintainers
+*       @hyperledger/fabric-core-maintainers


### PR DESCRIPTION
Switch fabric-lib-go to use fabric-core-maintainers.