### PR TITLE
Add ed25519 support

### DIFF
--- a/bccsp/opts.go
+++ b/bccsp/opts.go
@@ -22,6 +22,9 @@ const (
 	// ECDSAReRand ECDSA key re-randomization
 	ECDSAReRand = "ECDSA_RERAND"
 
+	// ED25519 Algorithm
+	ED25519 = "ED25519"
+
 	// RSA at the default security level.
 	// Each BCCSP may or may not support default security level. If not supported than
 	// an error will be returned.
@@ -90,6 +93,21 @@ func (opts *ECDSAKeyGenOpts) Ephemeral() bool {
 	return opts.Temporary
 }
 
+type ED25519KeyGenOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key generation algorithm identifier (to be used).
+func (opts *ED25519KeyGenOpts) Algorithm() string {
+	return ED25519
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *ED25519KeyGenOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
 // ECDSAPKIXPublicKeyImportOpts contains options for ECDSA public key importation in PKIX format
 type ECDSAPKIXPublicKeyImportOpts struct {
 	Temporary bool
@@ -136,6 +154,38 @@ func (opts *ECDSAGoPublicKeyImportOpts) Algorithm() string {
 // Ephemeral returns true if the key to generate has to be ephemeral,
 // false otherwise.
 func (opts *ECDSAGoPublicKeyImportOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// ED25519PrivateKeyImportOpts contains options for ED25519 key importation from ed25519.PublicKey
+type ED25519PrivateKeyImportOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key importation algorithm identifier (to be used).
+func (opts *ED25519PrivateKeyImportOpts) Algorithm() string {
+	return ED25519
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *ED25519PrivateKeyImportOpts) Ephemeral() bool {
+	return opts.Temporary
+}
+
+// ED25519GoPublicKeyImportOpts contains options for ED25519 key importation from ed25519.PublicKey
+type ED25519GoPublicKeyImportOpts struct {
+	Temporary bool
+}
+
+// Algorithm returns the key importation algorithm identifier (to be used).
+func (opts *ED25519GoPublicKeyImportOpts) Algorithm() string {
+	return ED25519
+}
+
+// Ephemeral returns true if the key to generate has to be ephemeral,
+// false otherwise.
+func (opts *ED25519GoPublicKeyImportOpts) Ephemeral() bool {
 	return opts.Temporary
 }
 

--- a/bccsp/signer/signer.go
+++ b/bccsp/signer/signer.go
@@ -61,9 +61,16 @@ func (s *bccspCryptoSigner) Public() crypto.PublicKey {
 	return s.pk
 }
 
-// Sign signs digest with the private key, possibly using entropy from rand.
+// Sign signs digest or the full message with the private key,
+// possibly using entropy from rand.
 // For an (EC)DSA key, it should be a DER-serialised, ASN.1 signature
-// structure.
+// structure.For an ED25519 key, it should be a signature compatible
+// to the with the RFC 8032.
+//
+// If (EC)DSA signature, the hash must be passed as the "digestOrMsg"
+// parameter. Golang requires the full message to sign with the
+// built-in ED25519 library. Therefore, the full message must be
+// passed as the "digestOrMsg" parameter.
 //
 // Hash implements the SignerOpts interface and, in most cases, one can
 // simply pass in the hash function used as opts. Sign may also attempt
@@ -73,6 +80,6 @@ func (s *bccspCryptoSigner) Public() crypto.PublicKey {
 // Note that when a signature of a hash of a larger message is needed,
 // the caller is responsible for hashing the larger message and passing
 // the hash (as digest) and the hash function (as opts) to Sign.
-func (s *bccspCryptoSigner) Sign(rand io.Reader, digest []byte, opts crypto.SignerOpts) ([]byte, error) {
-	return s.csp.Sign(s.key, digest, opts)
+func (s *bccspCryptoSigner) Sign(rand io.Reader, digestOrMsg []byte, opts crypto.SignerOpts) ([]byte, error) {
+	return s.csp.Sign(s.key, digestOrMsg, opts)
 }

--- a/bccsp/sw/ed25519.go
+++ b/bccsp/sw/ed25519.go
@@ -1,0 +1,40 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package sw
+
+import (
+	"crypto/ed25519"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp"
+)
+
+func signED25519(k *ed25519.PrivateKey, msg []byte, opts bccsp.SignerOpts) ([]byte, error) {
+	signature := ed25519.Sign(*k, msg)
+	return signature, nil
+}
+
+func verifyED25519(k *ed25519.PublicKey, signature, msg []byte, opts bccsp.SignerOpts) (bool, error) {
+	return ed25519.Verify(*k, msg, signature), nil
+}
+
+type ed25519Signer struct{}
+
+func (s *ed25519Signer) Sign(k bccsp.Key, msg []byte, opts bccsp.SignerOpts) ([]byte, error) {
+	return signED25519(k.(*ed25519PrivateKey).privKey, msg, opts)
+}
+
+type ed25519PrivateKeyVerifier struct{}
+
+func (v *ed25519PrivateKeyVerifier) Verify(k bccsp.Key, signature, msg []byte, opts bccsp.SignerOpts) (bool, error) {
+	castedKey, _ := (k.(*ed25519PrivateKey).privKey.Public()).(ed25519.PublicKey)
+	return verifyED25519(&castedKey, signature, msg, opts)
+}
+
+type ed25519PublicKeyKeyVerifier struct{}
+
+func (v *ed25519PublicKeyKeyVerifier) Verify(k bccsp.Key, signature, msg []byte, opts bccsp.SignerOpts) (bool, error) {
+	return verifyED25519(k.(*ed25519PublicKey).pubKey, signature, msg, opts)
+}

--- a/bccsp/sw/ed25519_test.go
+++ b/bccsp/sw/ed25519_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package sw
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyED25519(t *testing.T) {
+	t.Parallel()
+
+	// Generate a key
+	_, lowLevelKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	msg := []byte("hello world")
+	sigma, err := signED25519(&lowLevelKey, msg, nil)
+	require.NoError(t, err)
+
+	castedKey, _ := lowLevelKey.Public().(ed25519.PublicKey)
+	valid, err := verifyED25519(&castedKey, sigma, msg, nil)
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
+func TestEd25519SignerSign(t *testing.T) {
+	t.Parallel()
+
+	signer := &ed25519Signer{}
+	verifierPrivateKey := &ed25519PrivateKeyVerifier{}
+	verifierPublicKey := &ed25519PublicKeyKeyVerifier{}
+
+	// Generate a key
+	_, lowLevelKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	k := &ed25519PrivateKey{&lowLevelKey}
+	pk, err := k.PublicKey()
+	require.NoError(t, err)
+
+	// Sign
+	msg := []byte("Hello World")
+	sigma, err := signer.Sign(k, msg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, sigma)
+
+	// Verify
+	castedKey, _ := lowLevelKey.Public().(ed25519.PublicKey)
+	valid, err := verifyED25519(&castedKey, sigma, msg, nil)
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	valid, err = verifierPrivateKey.Verify(k, sigma, msg, nil)
+	require.NoError(t, err)
+	require.True(t, valid)
+
+	valid, err = verifierPublicKey.Verify(pk, sigma, msg, nil)
+	require.NoError(t, err)
+	require.True(t, valid)
+}
+
+func TestEd25519PrivateKey(t *testing.T) {
+	t.Parallel()
+
+	_, lowLevelKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	k := &ed25519PrivateKey{&lowLevelKey}
+
+	require.False(t, k.Symmetric())
+	require.True(t, k.Private())
+
+	_, err = k.Bytes()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Not supported.")
+
+	k.privKey = nil
+	ski := k.SKI()
+	require.Nil(t, ski)
+
+	k.privKey = &lowLevelKey
+	ski = k.SKI()
+	raw := k.privKey.Public().(ed25519.PublicKey)
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	require.Equal(t, ski2, ski, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	require.NoError(t, err)
+	require.NotNil(t, pk)
+	ed25519PK, ok := pk.(*ed25519PublicKey)
+	require.True(t, ok)
+	castedKey, _ := lowLevelKey.Public().(ed25519.PublicKey)
+	require.Equal(t, &castedKey, ed25519PK.pubKey)
+}
+
+func TestEd25519PublicKey(t *testing.T) {
+	t.Parallel()
+
+	_, lowLevelKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	castedKey, _ := lowLevelKey.Public().(ed25519.PublicKey)
+	k := &ed25519PublicKey{&castedKey}
+
+	require.False(t, k.Symmetric())
+	require.False(t, k.Private())
+
+	k.pubKey = nil
+	ski := k.SKI()
+	require.Nil(t, ski)
+
+	k.pubKey = &castedKey
+	ski = k.SKI()
+	raw := *(k.pubKey)
+	hash := sha256.New()
+	hash.Write(raw)
+	ski2 := hash.Sum(nil)
+	require.Equal(t, ski, ski2, "SKI is not computed in the right way.")
+
+	pk, err := k.PublicKey()
+	require.NoError(t, err)
+	require.Equal(t, k, pk)
+
+	bytes, err := k.Bytes()
+	require.NoError(t, err)
+	bytes2, err := x509.MarshalPKIXPublicKey(*k.pubKey)
+	require.NoError(t, err)
+	require.Equal(t, bytes2, bytes, "bytes are not computed in the right way.")
+}

--- a/bccsp/sw/ed25519key.go
+++ b/bccsp/sw/ed25519key.go
@@ -1,0 +1,109 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+package sw
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp"
+)
+
+type ed25519PrivateKey struct {
+	privKey *ed25519.PrivateKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *ed25519PrivateKey) Bytes() ([]byte, error) {
+	return nil, errors.New("Not supported.")
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *ed25519PrivateKey) SKI() []byte {
+	if k.privKey == nil {
+		return nil
+	}
+
+	// Marshall the public key
+	raw := k.privKey.Public().(ed25519.PublicKey)
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false if this key is asymmetric
+func (k *ed25519PrivateKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is a private key,
+// false otherwise.
+func (k *ed25519PrivateKey) Private() bool {
+	return true
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *ed25519PrivateKey) PublicKey() (bccsp.Key, error) {
+	castedKey, ok := k.privKey.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, errors.New("Error casting ed25519 public key")
+	}
+	return &ed25519PublicKey{&castedKey}, nil
+}
+
+type ed25519PublicKey struct {
+	pubKey *ed25519.PublicKey
+}
+
+// Bytes converts this key to its byte representation,
+// if this operation is allowed.
+func (k *ed25519PublicKey) Bytes() (raw []byte, err error) {
+	raw, err = x509.MarshalPKIXPublicKey(*k.pubKey)
+	if err != nil {
+		return nil, fmt.Errorf("Failed marshalling key [%s]", err)
+	}
+	return
+}
+
+// SKI returns the subject key identifier of this key.
+func (k *ed25519PublicKey) SKI() []byte {
+	if k.pubKey == nil {
+		return nil
+	}
+
+	raw := *(k.pubKey)
+
+	// Hash it
+	hash := sha256.New()
+	hash.Write(raw)
+	return hash.Sum(nil)
+}
+
+// Symmetric returns true if this key is a symmetric key,
+// false if this key is asymmetric
+func (k *ed25519PublicKey) Symmetric() bool {
+	return false
+}
+
+// Private returns true if this key is a private key,
+// false otherwise.
+func (k *ed25519PublicKey) Private() bool {
+	return false
+}
+
+// PublicKey returns the corresponding public key part of an asymmetric public/private key pair.
+// This method returns an error in symmetric key schemes.
+func (k *ed25519PublicKey) PublicKey() (bccsp.Key, error) {
+	return k, nil
+}

--- a/bccsp/sw/keygen.go
+++ b/bccsp/sw/keygen.go
@@ -8,6 +8,7 @@ package sw
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -27,6 +28,17 @@ func (kg *ecdsaKeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
 	}
 
 	return &ecdsaPrivateKey{privKey}, nil
+}
+
+type ed25519KeyGenerator struct{}
+
+func (kg *ed25519KeyGenerator) KeyGen(opts bccsp.KeyGenOpts) (bccsp.Key, error) {
+	_, privKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("Failed generating ED25519 key: [%s]", err)
+	}
+
+	return &ed25519PrivateKey{&privKey}, nil
 }
 
 type aesKeyGenerator struct {

--- a/bccsp/sw/keygen_test.go
+++ b/bccsp/sw/keygen_test.go
@@ -61,6 +61,19 @@ func TestECDSAKeyGenerator(t *testing.T) {
 	require.Equal(t, ecdsaK.privKey.Curve, elliptic.P256())
 }
 
+func TestED25519KeyGenerator(t *testing.T) {
+	t.Parallel()
+
+	kg := &ed25519KeyGenerator{}
+
+	k, err := kg.KeyGen(nil)
+	require.NoError(t, err)
+
+	ed25519K, ok := k.(*ed25519PrivateKey)
+	require.True(t, ok)
+	require.NotNil(t, ed25519K.privKey)
+}
+
 func TestAESKeyGenerator(t *testing.T) {
 	t.Parallel()
 

--- a/bccsp/sw/keyimport_test.go
+++ b/bccsp/sw/keyimport_test.go
@@ -161,6 +161,35 @@ func TestECDSAPrivateKeyImportOptsKeyImporter(t *testing.T) {
 	require.Contains(t, err.Error(), "Failed casting to ECDSA private key. Invalid raw material.")
 }
 
+func TestED25519PrivateKeyImportOptsKeyImporter(t *testing.T) {
+	t.Parallel()
+
+	ki := ed25519PrivateKeyImportOptsKeyImporter{}
+
+	_, err := ki.KeyImport("Hello World", &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid raw material. Expected byte array.")
+
+	_, err = ki.KeyImport(nil, &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid raw material. Expected byte array.")
+
+	_, err = ki.KeyImport([]byte(nil), &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid raw. It must not be nil.")
+
+	_, err = ki.KeyImport([]byte{0}, &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Failed converting PKIX to ED25519 public key")
+
+	k, err := rsa.GenerateKey(rand.Reader, 512)
+	require.NoError(t, err)
+	raw := x509.MarshalPKCS1PrivateKey(k)
+	_, err = ki.KeyImport(raw, &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Failed casting to ED25519 private key. Invalid raw material.")
+}
+
 func TestECDSAGoPublicKeyImportOptsKeyImporter(t *testing.T) {
 	t.Parallel()
 
@@ -173,6 +202,20 @@ func TestECDSAGoPublicKeyImportOptsKeyImporter(t *testing.T) {
 	_, err = ki.KeyImport(nil, &mocks2.KeyImportOpts{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Invalid raw material. Expected *ecdsa.PublicKey.")
+}
+
+func TestED25519GoPublicKeyImportOptsKeyImporter(t *testing.T) {
+	t.Parallel()
+
+	ki := ed25519GoPublicKeyImportOptsKeyImporter{}
+
+	_, err := ki.KeyImport("Hello World", &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid raw material. Expected *ed25519.PublicKey.")
+
+	_, err = ki.KeyImport(nil, &mocks2.KeyImportOpts{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Invalid raw material. Expected *ed25519.PublicKey.")
 }
 
 func TestX509PublicKeyImportOptsKeyImporter(t *testing.T) {
@@ -192,7 +235,7 @@ func TestX509PublicKeyImportOptsKeyImporter(t *testing.T) {
 	cert.PublicKey = "Hello world"
 	_, err = ki.KeyImport(cert, &mocks2.KeyImportOpts{})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA, RSA]")
+	require.Contains(t, err.Error(), "Certificate's public key type not recognized. Supported keys: [ECDSA, ED25519, RSA]")
 }
 
 func TestX509RSAKeyImport(t *testing.T) {

--- a/bccsp/sw/keys.go
+++ b/bccsp/sw/keys.go
@@ -7,7 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package sw
 
 import (
+	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
@@ -54,12 +56,20 @@ func oidFromNamedCurve(curve elliptic.Curve) (asn1.ObjectIdentifier, bool) {
 	return nil, false
 }
 
-func privateKeyToDER(privateKey *ecdsa.PrivateKey) ([]byte, error) {
+func privateKeyToDER(privateKey crypto.PrivateKey) ([]byte, error) {
 	if privateKey == nil {
-		return nil, errors.New("invalid ecdsa private key. It must be different from nil")
+		return nil, errors.New("invalid private key. It must be different from nil")
 	}
 
-	return x509.MarshalECPrivateKey(privateKey)
+	switch key := privateKey.(type) {
+	// Fabric supports ECDSA and ED25519 at the moment.
+	case *ecdsa.PrivateKey:
+		return x509.MarshalECPrivateKey(privateKey.(*ecdsa.PrivateKey))
+	case *ed25519.PrivateKey:
+		return x509.MarshalPKCS8PrivateKey(*privateKey.(*ed25519.PrivateKey))
+	default:
+		return nil, fmt.Errorf("found unknown private key type (%T) in marshaling", key)
+	}
 }
 
 func privateKeyToPEM(privateKey interface{}, pwd []byte) ([]byte, error) {
@@ -114,6 +124,21 @@ func privateKeyToPEM(privateKey interface{}, pwd []byte) ([]byte, error) {
 				Bytes: pkcs8Bytes,
 			},
 		), nil
+	case *ed25519.PrivateKey:
+		if k == nil {
+			return nil, errors.New("invalid ed25519 private key. It must be different from nil")
+		}
+
+		pkcs8Bytes, err := x509.MarshalPKCS8PrivateKey(*k)
+		if err != nil {
+			return nil, fmt.Errorf("error marshaling ED key to asn1: [%s]", err)
+		}
+		return pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "PRIVATE KEY",
+				Bytes: pkcs8Bytes,
+			},
+		), nil
 
 	case *rsa.PrivateKey:
 		if k == nil {
@@ -129,7 +154,7 @@ func privateKeyToPEM(privateKey interface{}, pwd []byte) ([]byte, error) {
 		), nil
 
 	default:
-		return nil, errors.New("invalid key type. It must be *ecdsa.PrivateKey or *rsa.PrivateKey")
+		return nil, errors.New("invalid key type. It must be *ecdsa.PrivateKey, *ed25519.PrivateKey or *rsa.PrivateKey")
 	}
 }
 
@@ -159,9 +184,29 @@ func privateKeyToEncryptedPEM(privateKey interface{}, pwd []byte) ([]byte, error
 		}
 
 		return pem.EncodeToMemory(block), nil
+	case *ed25519.PrivateKey:
+		if k == nil {
+			return nil, errors.New("invalid ed25519 private key. It must be different from nil")
+		}
+		raw, err := x509.MarshalPKCS8PrivateKey(*k)
+		if err != nil {
+			return nil, err
+		}
+
+		block, err := x509.EncryptPEMBlock(
+			rand.Reader,
+			"PRIVATE KEY",
+			raw,
+			pwd,
+			x509.PEMCipherAES256)
+		if err != nil {
+			return nil, err
+		}
+
+		return pem.EncodeToMemory(block), nil
 
 	default:
-		return nil, errors.New("invalid key type. It must be *ecdsa.PrivateKey")
+		return nil, errors.New("invalid key type. It must be *ecdsa.PrivateKey or *ed25519.PrivateKey")
 	}
 }
 
@@ -174,6 +219,8 @@ func derToPrivateKey(der []byte) (key interface{}, err error) {
 		switch key.(type) {
 		case *ecdsa.PrivateKey:
 			return
+		case ed25519.PrivateKey:
+			return
 		default:
 			return nil, errors.New("found unknown private key type in PKCS#8 wrapping")
 		}
@@ -183,7 +230,7 @@ func derToPrivateKey(der []byte) (key interface{}, err error) {
 		return
 	}
 
-	return nil, errors.New("invalid key type. The DER must contain an ecdsa.PrivateKey")
+	return nil, errors.New("invalid key type. The DER must contain an ecdsa.PrivateKey or an ed25519.PrivateKey")
 }
 
 func pemToPrivateKey(raw []byte, pwd []byte) (interface{}, error) {
@@ -292,6 +339,21 @@ func publicKeyToPEM(publicKey interface{}, pwd []byte) ([]byte, error) {
 				Bytes: PubASN1,
 			},
 		), nil
+	case *ed25519.PublicKey:
+		if k == nil {
+			return nil, errors.New("invalid ed25519 public key. It must be different from nil")
+		}
+		PubASN1, err := x509.MarshalPKIXPublicKey(*k)
+		if err != nil {
+			return nil, err
+		}
+
+		return pem.EncodeToMemory(
+			&pem.Block{
+				Type:  "PUBLIC KEY",
+				Bytes: PubASN1,
+			},
+		), nil
 
 	case *rsa.PublicKey:
 		if k == nil {
@@ -310,7 +372,7 @@ func publicKeyToPEM(publicKey interface{}, pwd []byte) ([]byte, error) {
 		), nil
 
 	default:
-		return nil, errors.New("invalid key type. It must be *ecdsa.PublicKey or *rsa.PublicKey")
+		return nil, errors.New("invalid key type. It must be *ecdsa.PublicKey, *ed25519.PublicKey or *rsa.PublicKey")
 	}
 }
 
@@ -336,8 +398,28 @@ func publicKeyToEncryptedPEM(publicKey interface{}, pwd []byte) ([]byte, error) 
 		}
 
 		return pem.EncodeToMemory(block), nil
+	case *ed25519.PublicKey:
+		if k == nil {
+			return nil, errors.New("invalid ed25519 public key. It must be different from nil")
+		}
+		raw, err := x509.MarshalPKIXPublicKey(*k)
+		if err != nil {
+			return nil, err
+		}
+
+		block, err := x509.EncryptPEMBlock(
+			rand.Reader,
+			"PUBLIC KEY",
+			raw,
+			pwd,
+			x509.PEMCipherAES256)
+		if err != nil {
+			return nil, err
+		}
+
+		return pem.EncodeToMemory(block), nil
 	default:
-		return nil, errors.New("invalid key type. It must be *ecdsa.PublicKey")
+		return nil, errors.New("invalid key type. It must be *ecdsa.PublicKey or *ed25519.PublicKey")
 	}
 }
 

--- a/bccsp/sw/new.go
+++ b/bccsp/sw/new.go
@@ -60,11 +60,14 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 
 	// Set the Signers
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaSigner{})
+	swbccsp.AddWrapper(reflect.TypeOf(&ed25519PrivateKey{}), &ed25519Signer{})
 	swbccsp.AddWrapper(reflect.TypeOf(&rsaPrivateKey{}), &rsaSigner{})
 
 	// Set the Verifiers
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaPrivateKeyVerifier{})
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPublicKey{}), &ecdsaPublicKeyKeyVerifier{})
+	swbccsp.AddWrapper(reflect.TypeOf(&ed25519PrivateKey{}), &ed25519PrivateKeyVerifier{})
+	swbccsp.AddWrapper(reflect.TypeOf(&ed25519PublicKey{}), &ed25519PublicKeyKeyVerifier{})
 	swbccsp.AddWrapper(reflect.TypeOf(&rsaPrivateKey{}), &rsaPrivateKeyVerifier{})
 	swbccsp.AddWrapper(reflect.TypeOf(&rsaPublicKey{}), &rsaPublicKeyKeyVerifier{})
 
@@ -83,6 +86,7 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES256KeyGenOpts{}), &aesKeyGenerator{length: 32})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES192KeyGenOpts{}), &aesKeyGenerator{length: 24})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES128KeyGenOpts{}), &aesKeyGenerator{length: 16})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ED25519KeyGenOpts{}), &ed25519KeyGenerator{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSAKeyGenOpts{}), &rsaKeyGenerator{length: conf.rsaBitLength})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA1024KeyGenOpts{}), &rsaKeyGenerator{length: 1024})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSA2048KeyGenOpts{}), &rsaKeyGenerator{length: 2048})
@@ -93,6 +97,8 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPrivateKey{}), &ecdsaPrivateKeyKeyDeriver{})
 	swbccsp.AddWrapper(reflect.TypeOf(&ecdsaPublicKey{}), &ecdsaPublicKeyKeyDeriver{})
 	swbccsp.AddWrapper(reflect.TypeOf(&aesPrivateKey{}), &aesPrivateKeyKeyDeriver{conf: conf})
+	// TODO: Ed25519 KeyDeriver
+	// swbccsp.AddWrapper(reflect.TypeOf(&ed25519PrivateKey{}), &ed25519PrivateKeyKeyDeriver{})
 
 	// Set the key importers
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.AES256ImportKeyOpts{}), &aes256ImportKeyOptsKeyImporter{})
@@ -102,6 +108,8 @@ func NewWithParams(securityLevel int, hashFamily string, keyStore bccsp.KeyStore
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ECDSAGoPublicKeyImportOpts{}), &ecdsaGoPublicKeyImportOptsKeyImporter{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.RSAGoPublicKeyImportOpts{}), &rsaGoPublicKeyImportOptsKeyImporter{})
 	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.X509PublicKeyImportOpts{}), &x509PublicKeyImportOptsKeyImporter{bccsp: swbccsp})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ED25519PrivateKeyImportOpts{}), &ed25519PrivateKeyImportOptsKeyImporter{})
+	swbccsp.AddWrapper(reflect.TypeOf(&bccsp.ED25519GoPublicKeyImportOpts{}), &ed25519GoPublicKeyImportOptsKeyImporter{})
 
 	return swbccsp, nil
 }


### PR DESCRIPTION
This is related to fabric pull request [#3343](https://github.com/hyperledger/fabric/pull/3343) regarding adding ed25519 support. Since the bccsp folder was moved to fabric-lib-go, I am moving the related changes here.