### PR TITLE
Bump Go and ubuntu versions to match fabric

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,12 @@ on:
 env:
   GOPATH: /opt/go
   PATH: /opt/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
-  GO_VER: 1.21.9
+  GO_VER: 1.24.2
 
 jobs:
   unit-tests:
     name: Unit Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v3

--- a/bccsp/sw/keyimport_test.go
+++ b/bccsp/sw/keyimport_test.go
@@ -123,7 +123,7 @@ func TestECDSAPKIXPublicKeyImportOptsKeyImporter(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Failed converting PKIX to ECDSA public key [")
 
-	k, err := rsa.GenerateKey(rand.Reader, 512)
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 	raw, err := x509.MarshalPKIXPublicKey(&k.PublicKey)
 	require.NoError(t, err)
@@ -153,7 +153,7 @@ func TestECDSAPrivateKeyImportOptsKeyImporter(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Failed converting PKIX to ECDSA public key")
 
-	k, err := rsa.GenerateKey(rand.Reader, 512)
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 	raw := x509.MarshalPKCS1PrivateKey(k)
 	_, err = ki.KeyImport(raw, &mocks2.KeyImportOpts{})
@@ -182,7 +182,7 @@ func TestED25519PrivateKeyImportOptsKeyImporter(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Failed converting PKIX to ED25519 public key")
 
-	k, err := rsa.GenerateKey(rand.Reader, 512)
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
 	require.NoError(t, err)
 	raw := x509.MarshalPKCS1PrivateKey(k)
 	_, err = ki.KeyImport(raw, &mocks2.KeyImportOpts{})

--- a/common/flogging/fabenc/formatter_test.go
+++ b/common/flogging/fabenc/formatter_test.go
@@ -75,7 +75,7 @@ func TestParseFormat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		t.Run(fmt.Sprintf(tc.desc), func(t *testing.T) {
+		t.Run(tc.desc, func(t *testing.T) {
 			formatters, err := fabenc.ParseFormat(tc.spec)
 			require.NoError(t, err)
 			require.Equal(t, tc.formatters, formatters)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-lib-go
 
-go 1.23.4
+go 1.24.2
 
 require (
 	github.com/go-kit/kit v0.13.0


### PR DESCRIPTION
Bump Go and ubuntu versions to match fabric.

Also update tests to be compatible with Go 1.24.