### PR TITLE
In order for viper to work properly in fabric

### DIFF
--- a/bccsp/factory/nopkcs11.go
+++ b/bccsp/factory/nopkcs11.go
@@ -19,6 +19,16 @@ import (
 
 const pkcs11Enabled = false
 
+func getDefaultImpl() *FactoryOpts {
+	return &FactoryOpts{
+		Default: "",
+		SW: &SwOpts{
+			Security: 0,
+			Hash:     "",
+		},
+	}
+}
+
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
 	Default string  `json:"default" yaml:"Default"`

--- a/bccsp/factory/opts.go
+++ b/bccsp/factory/opts.go
@@ -9,13 +9,11 @@ package factory
 // GetDefaultOpts offers a default implementation for Opts
 // returns a new instance every time
 func GetDefaultOpts() *FactoryOpts {
-	return &FactoryOpts{
-		Default: "SW",
-		SW: &SwOpts{
-			Hash:     "SHA2",
-			Security: 256,
-		},
-	}
+	fopts := getDefaultImpl()
+	fopts.Default = "SW"
+	fopts.SW.Hash = "SHA2"
+	fopts.SW.Security = 256
+	return fopts
 }
 
 // FactoryName returns the name of the provider

--- a/bccsp/factory/pkcs11.go
+++ b/bccsp/factory/pkcs11.go
@@ -21,6 +21,27 @@ import (
 
 const pkcs11Enabled = false
 
+func getDefaultImpl() *FactoryOpts {
+	return &FactoryOpts{
+		Default: "",
+		SW: &SwOpts{
+			Security: 0,
+			Hash:     "",
+		},
+		PKCS11: &pkcs11.PKCS11Opts{
+			Security:       0,
+			Hash:           "",
+			Library:        "",
+			Label:          "",
+			Pin:            "",
+			SoftwareVerify: false,
+			Immutable:      false,
+			AltID:          "",
+			KeyIDs:         nil,
+		},
+	}
+}
+
 // FactoryOpts holds configuration information used to initialize factory implementations
 type FactoryOpts struct {
 	Default string             `json:"default" yaml:"Default"`


### PR DESCRIPTION
it is necessary to return all fields that can be overwritten via environment variables.

https://github.com/hyperledger/fabric/issues/5272